### PR TITLE
Junit5 assert throws

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -40,6 +40,11 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/core/src/test/java/org/apache/commons/proxy2/AbstractProxyFactoryTestCase.java
+++ b/core/src/test/java/org/apache/commons/proxy2/AbstractProxyFactoryTestCase.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
 import java.io.Serializable;
@@ -45,6 +46,7 @@ import org.apache.commons.proxy2.util.Echo;
 import org.apache.commons.proxy2.util.EchoImpl;
 import org.apache.commons.proxy2.util.SuffixInterceptor;
 import org.junit.Test;
+import org.junit.jupiter.api.function.Executable;
 
 @SuppressWarnings("serial")
 public abstract class AbstractProxyFactoryTestCase extends AbstractTestCase
@@ -221,18 +223,32 @@ public abstract class AbstractProxyFactoryTestCase extends AbstractTestCase
         assertSerializable(proxy);
     }
 
-    @Test(expected = IOException.class)
-    public void testInterceptorProxyWithCheckedException() throws Exception
+    @Test
+    public void testInterceptorProxyWithCheckedException()
     {
         final Echo proxy = factory.createInterceptorProxy(new EchoImpl(), new NoOpMethodInterceptor(), ECHO_ONLY);
-        proxy.ioException();
+        // FIXME Simplification once upgraded to Java 1.8
+        final Executable testMethod = new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                proxy.ioException();
+            }
+        };
+        assertThrows(IOException.class, testMethod);
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testInterceptorProxyWithUncheckedException() throws Exception
+    @Test
+    public void testInterceptorProxyWithUncheckedException()
     {
         final Echo proxy = factory.createInterceptorProxy(new EchoImpl(), new NoOpMethodInterceptor(), ECHO_ONLY);
-        proxy.illegalArgument();
+        // FIXME Simplification once upgraded to Java 1.8
+        final Executable testMethod = new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                proxy.illegalArgument();
+            }
+        };
+        assertThrows(IllegalArgumentException.class, testMethod);
     }
 
     @Test
@@ -326,18 +342,32 @@ public abstract class AbstractProxyFactoryTestCase extends AbstractTestCase
         assertEquals(1, echo.echoBack(1));
     }
 
-    @Test(expected = IOException.class)
-    public void testProxyWithCheckedException() throws Exception
+    @Test
+    public void testProxyWithCheckedException()
     {
         final Echo proxy = factory.createDelegatorProxy(new ConstantProvider<Echo>(new EchoImpl()), Echo.class);
-        proxy.ioException();
+        // FIXME Simplification once upgraded to Java 1.8
+        final Executable testMethod = new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                proxy.ioException();
+            }
+        };
+        assertThrows(IOException.class, testMethod);
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testProxyWithUncheckedException() throws Exception
+    @Test
+    public void testProxyWithUncheckedException()
     {
         final Echo proxy = factory.createDelegatorProxy(new ConstantProvider<Echo>(new EchoImpl()), Echo.class);
-        proxy.illegalArgument();
+        // FIXME Simplification once upgraded to Java 1.8
+        final Executable testMethod = new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                proxy.illegalArgument();
+            }
+        };
+        assertThrows(IllegalArgumentException.class, testMethod);
     }
 
     @Test

--- a/core/src/test/java/org/apache/commons/proxy2/AbstractSubclassingProxyFactoryTestCase.java
+++ b/core/src/test/java/org/apache/commons/proxy2/AbstractSubclassingProxyFactoryTestCase.java
@@ -20,6 +20,7 @@ package org.apache.commons.proxy2;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Date;
 
@@ -30,6 +31,7 @@ import org.apache.commons.proxy2.util.AbstractEcho;
 import org.apache.commons.proxy2.util.Echo;
 import org.apache.commons.proxy2.util.EchoImpl;
 import org.junit.Test;
+import org.junit.jupiter.api.function.Executable;
 
 @SuppressWarnings("serial")
 public abstract class AbstractSubclassingProxyFactoryTestCase extends AbstractProxyFactoryTestCase
@@ -72,11 +74,18 @@ public abstract class AbstractSubclassingProxyFactoryTestCase extends AbstractPr
         assertFalse(proxy2.equals(proxy1));
     }
 
-    @Test(expected = ProxyFactoryException.class)
+    @Test
     public void testDelegatorWithMultipleSuperclasses()
     {
-        factory.createDelegatorProxy(new ConstantProvider<EchoImpl>(new EchoImpl()), new Class[] { EchoImpl.class,
-                String.class });
+        // FIXME Simplification once upgraded to Java 1.8
+        final Executable testMethod = new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                factory.createDelegatorProxy(new ConstantProvider<EchoImpl>(new EchoImpl()), new Class[]{EchoImpl.class,
+                        String.class});
+            }
+        };
+        assertThrows(ProxyFactoryException.class, testMethod);
     }
 
     @Test
@@ -101,11 +110,18 @@ public abstract class AbstractSubclassingProxyFactoryTestCase extends AbstractPr
         assertFalse(proxy2.equals(proxy1));
     }
 
-    @Test(expected = ProxyFactoryException.class)
+    @Test
     public void testInterceptorWithMultipleSuperclasses()
     {
-        factory.createInterceptorProxy(new EchoImpl(), new NoOpMethodInterceptor(), new Class[] { EchoImpl.class,
-                String.class });
+        // FIXME Simplification once upgraded to Java 1.8
+        final Executable testMethod = new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                factory.createInterceptorProxy(new EchoImpl(), new NoOpMethodInterceptor(), new Class[]{EchoImpl.class,
+                        String.class});
+            }
+        };
+        assertThrows(ProxyFactoryException.class, testMethod);
     }
 
     @Test
@@ -116,10 +132,17 @@ public abstract class AbstractSubclassingProxyFactoryTestCase extends AbstractPr
         assertTrue(echo instanceof EchoImpl);
     }
 
-    @Test(expected = ProxyFactoryException.class)
+    @Test
     public void testInvocationHandlerWithMultipleSuperclasses()
     {
-        factory.createInvokerProxy(new NullInvoker(), new Class[] { EchoImpl.class, String.class });
+        // FIXME Simplification once upgraded to Java 1.8
+        final Executable testMethod = new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                factory.createInvokerProxy(new NullInvoker(), new Class[]{EchoImpl.class, String.class});
+            }
+        };
+        assertThrows(ProxyFactoryException.class, testMethod);
     }
 
     @Override

--- a/core/src/test/java/org/apache/commons/proxy2/interceptor/InterceptorUtilsTest.java
+++ b/core/src/test/java/org/apache/commons/proxy2/interceptor/InterceptorUtilsTest.java
@@ -18,6 +18,7 @@
 package org.apache.commons.proxy2.interceptor;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.apache.commons.proxy2.Interceptor;
 import org.apache.commons.proxy2.Invocation;
@@ -25,6 +26,7 @@ import org.apache.commons.proxy2.provider.ObjectProviderUtils;
 import org.apache.commons.proxy2.util.AbstractTestCase;
 import org.apache.commons.proxy2.util.Echo;
 import org.junit.Test;
+import org.junit.jupiter.api.function.Executable;
 
 public class InterceptorUtilsTest extends AbstractTestCase
 {
@@ -44,21 +46,35 @@ public class InterceptorUtilsTest extends AbstractTestCase
         assertEquals("Foo!", interceptor.intercept(invocation));
     }
 
-    @Test(expected = RuntimeException.class)
-    public void testThrowingExceptionObject() throws Throwable
+    @Test
+    public void testThrowingExceptionObject()
     {
-        Interceptor interceptor = InterceptorUtils.throwing(new RuntimeException("Oops!"));
-        Invocation invocation = mockInvocation(Echo.class, "echoBack", String.class).withArguments("World!").build();
-        interceptor.intercept(invocation);
+        final Interceptor interceptor = InterceptorUtils.throwing(new RuntimeException("Oops!"));
+        final Invocation invocation = mockInvocation(Echo.class, "echoBack", String.class).withArguments("World!").build();
+        // FIXME Simplification once upgraded to Java 1.8
+        final Executable testMethod = new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                interceptor.intercept(invocation);
+            }
+        };
+        assertThrows(RuntimeException.class, testMethod);
     }
 
-    @Test(expected = RuntimeException.class)
-    public void testThrowingProvidedException() throws Throwable
+    @Test
+    public void testThrowingProvidedException()
     {
-        Interceptor interceptor = InterceptorUtils
+        final Interceptor interceptor = InterceptorUtils
                 .throwing(ObjectProviderUtils.constant(new RuntimeException("Oops!")));
-        Invocation invocation = mockInvocation(Echo.class, "echoBack", String.class).withArguments("World!").build();
-        interceptor.intercept(invocation);
+        final Invocation invocation = mockInvocation(Echo.class, "echoBack", String.class).withArguments("World!").build();
+        // FIXME Simplification once upgraded to Java 1.8
+        final Executable testMethod = new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                interceptor.intercept(invocation);
+            }
+        };
+        assertThrows(RuntimeException.class, testMethod);
     }
 
 }

--- a/core/src/test/java/org/apache/commons/proxy2/interceptor/InvokerInterceptorTest.java
+++ b/core/src/test/java/org/apache/commons/proxy2/interceptor/InvokerInterceptorTest.java
@@ -19,6 +19,7 @@ package org.apache.commons.proxy2.interceptor;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.lang.reflect.Method;
 
@@ -27,6 +28,7 @@ import org.apache.commons.proxy2.Invoker;
 import org.apache.commons.proxy2.util.AbstractTestCase;
 import org.apache.commons.proxy2.util.Echo;
 import org.junit.Test;
+import org.junit.jupiter.api.function.Executable;
 
 public class InvokerInterceptorTest extends AbstractTestCase
 {
@@ -53,9 +55,16 @@ public class InvokerInterceptorTest extends AbstractTestCase
         assertEquals("Hello!", interceptor.intercept(invocation));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testWithNullInvoker()
     {
-        assertNotNull(new InvokerInterceptor(null)); // assert is used to avoid not used warning
+        // FIXME Simplification once upgraded to Java 1.8
+        final Executable testMethod = new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                new InvokerInterceptor(null);
+            }
+        };
+        assertThrows(NullPointerException.class, testMethod);
     }
 }

--- a/core/src/test/java/org/apache/commons/proxy2/interceptor/ObjectProviderInterceptorTest.java
+++ b/core/src/test/java/org/apache/commons/proxy2/interceptor/ObjectProviderInterceptorTest.java
@@ -19,10 +19,12 @@ package org.apache.commons.proxy2.interceptor;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.apache.commons.proxy2.provider.ObjectProviderUtils;
 import org.apache.commons.proxy2.util.AbstractTestCase;
 import org.junit.Test;
+import org.junit.jupiter.api.function.Executable;
 
 public class ObjectProviderInterceptorTest extends AbstractTestCase
 {
@@ -37,9 +39,16 @@ public class ObjectProviderInterceptorTest extends AbstractTestCase
         assertEquals("Hello!", interceptor.intercept(null));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testWithNullProvider()
     {
-        assertNotNull(new ObjectProviderInterceptor(null)); // assert is used to avoid not used warning
+        // FIXME Simplification once upgraded to Java 1.8
+        final Executable testMethod = new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                new ObjectProviderInterceptor(null);
+            }
+        };
+        assertThrows(NullPointerException.class, testMethod);
     }
 }

--- a/core/src/test/java/org/apache/commons/proxy2/provider/BeanProviderTest.java
+++ b/core/src/test/java/org/apache/commons/proxy2/provider/BeanProviderTest.java
@@ -20,6 +20,9 @@ package org.apache.commons.proxy2.provider;
 import org.apache.commons.proxy2.exception.ObjectProviderException;
 import org.apache.commons.proxy2.util.AbstractTestCase;
 import org.junit.Test;
+import org.junit.jupiter.api.function.Executable;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class BeanProviderTest extends AbstractTestCase
 {
@@ -27,17 +30,31 @@ public class BeanProviderTest extends AbstractTestCase
     // Other Methods
     //**********************************************************************************************************************
 
-    @Test(expected = ObjectProviderException.class)
+    @Test
     public void testAbstractBeanClass()
     {
         final BeanProvider<Number> p = new BeanProvider<Number>(Number.class);
-        p.getObject();
+        // FIXME Simplification once upgraded to Java 1.8
+        final Executable testMethod = new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                p.getObject();
+            }
+        };
+        assertThrows(ObjectProviderException.class, testMethod);
     }
 
-    @Test(expected = ObjectProviderException.class)
+    @Test
     public void testNonAccessibleConstructor()
     {
-        new BeanProvider<MyBean>(MyBean.class).getObject();
+        // FIXME Simplification once upgraded to Java 1.8
+        final Executable testMethod = new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                new BeanProvider<MyBean>(MyBean.class).getObject();
+            }
+        };
+        assertThrows(ObjectProviderException.class, testMethod);
     }
 
     @Test
@@ -46,11 +63,18 @@ public class BeanProviderTest extends AbstractTestCase
         assertSerializable(new BeanProvider<MyBean>(MyBean.class));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testWithNullBeanClass()
     {
         final BeanProvider<Object> p = new BeanProvider<Object>(null);
-        p.getObject();
+        // FIXME Simplification once upgraded to Java 1.8
+        final Executable testMethod = new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                p.getObject();
+            }
+        };
+        assertThrows(NullPointerException.class, testMethod);
     }
 
     //**********************************************************************************************************************

--- a/core/src/test/java/org/apache/commons/proxy2/provider/CloningProviderTest.java
+++ b/core/src/test/java/org/apache/commons/proxy2/provider/CloningProviderTest.java
@@ -21,12 +21,14 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Date;
 
 import org.apache.commons.proxy2.exception.ObjectProviderException;
 import org.apache.commons.proxy2.util.AbstractTestCase;
 import org.junit.Test;
+import org.junit.jupiter.api.function.Executable;
 
 public class CloningProviderTest extends AbstractTestCase
 {
@@ -69,18 +71,32 @@ public class CloningProviderTest extends AbstractTestCase
         }
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testWithInvalidCloneable()
     {
-        assertNotNull(new CloningProvider<InvalidCloneable>(new InvalidCloneable())); // assert is used to avoid not used warning
+        // FIXME Simplification once upgraded to Java 1.8
+        final Executable testMethod = new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                new CloningProvider<InvalidCloneable>(new InvalidCloneable());
+            }
+        };
+        assertThrows(IllegalArgumentException.class, testMethod);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testWithProtectedCloneMethod()
     {
         final CloningProvider<ProtectedCloneable> provider = new CloningProvider<ProtectedCloneable>(
                 new ProtectedCloneable());
-        provider.getObject();
+        // FIXME Simplification once upgraded to Java 1.8
+        final Executable testMethod = new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                provider.getObject();
+            }
+        };
+        assertThrows(IllegalArgumentException.class, testMethod);
     }
 
     //**********************************************************************************************************************

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -59,6 +59,11 @@
             <artifactId>commons-lang3</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/test/src/test/java/org/apache/commons/proxy2/serialization/SerializationProxyTest.java
+++ b/test/src/test/java/org/apache/commons/proxy2/serialization/SerializationProxyTest.java
@@ -18,6 +18,7 @@ package org.apache.commons.proxy2.serialization;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.Serializable;
 
@@ -31,6 +32,7 @@ import org.apache.commons.proxy2.AbstractProxyFactoryAgnosticTest;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.jupiter.api.function.Executable;
 
 public class SerializationProxyTest extends AbstractProxyFactoryAgnosticTest
 {
@@ -91,14 +93,21 @@ public class SerializationProxyTest extends AbstractProxyFactoryAgnosticTest
         PROXY_FACTORY.remove();
     }
 
-    @Test(expected = SerializationException.class)
+    @Test
     public void testNaive()
     {
         final Provider proxy = proxyFactory.createInterceptorProxy(null, implementProvider("foo"), Provider.class,
                 Serializable.class);
         assertEquals("foo", proxy.getObject().getValue());
         assertTrue(Serializable.class.isInstance(proxy));
-        SerializationUtils.roundtrip((Serializable) proxy);
+        // FIXME Simplification once upgraded to Java 1.8
+        final Executable testMethod = new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                SerializationUtils.roundtrip((Serializable) proxy);
+            }
+        };
+        assertThrows(SerializationException.class, testMethod);
     }
 
     @Test

--- a/test/src/test/java/org/apache/commons/proxy2/stub/AbstractStubTestCase.java
+++ b/test/src/test/java/org/apache/commons/proxy2/stub/AbstractStubTestCase.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Arrays;
 
@@ -28,6 +29,7 @@ import org.apache.commons.proxy2.invoker.NullInvoker;
 import org.apache.commons.proxy2.provider.ObjectProviderUtils;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.jupiter.api.function.Executable;
 
 public abstract class AbstractStubTestCase extends AbstractProxyFactoryAgnosticTest
 {
@@ -68,18 +70,23 @@ public abstract class AbstractStubTestCase extends AbstractProxyFactoryAgnosticT
         assertEquals("World", proxy.one(null));
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void testMixingArgumentMatchingStrategies()
     {
-        createProxy(new Trainer<StubInterface>()
-        {
+        // FIXME Simplification once upgraded to Java 1.8
+        final Executable testMethod = new Executable() {
             @Override
-            protected void train(StubInterface trainee)
-            {
-                when(trainee.three(isInstance(String.class), "World"))
-                        .thenAnswer(ObjectProviderUtils.constant("World"));
+            public void execute() throws Throwable {
+                createProxy(new Trainer<StubInterface>() {
+                    @Override
+                    protected void train(StubInterface trainee) {
+                        when(trainee.three(isInstance(String.class), "World"))
+                                .thenAnswer(ObjectProviderUtils.constant("World"));
+                    }
+                });
             }
-        });
+        };
+        assertThrows(IllegalStateException.class, testMethod);
     }
 
     @Test
@@ -134,23 +141,28 @@ public abstract class AbstractStubTestCase extends AbstractProxyFactoryAgnosticT
         assertEquals("One", proxy.stubs()[1].one("Whatever"));
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void testThenBeforeWhen()
     {
-        createProxy(new Trainer<StubInterface>()
-        {
+        // FIXME Simplification once upgraded to Java 1.8
+        final Executable testMethod = new Executable() {
             @Override
-            protected void train(StubInterface trainee)
-            {
-                thenThrow(new RuntimeException("Oops!"));
+            public void execute() throws Throwable {
+                createProxy(new Trainer<StubInterface>() {
+                    @Override
+                    protected void train(StubInterface trainee) {
+                        thenThrow(new RuntimeException("Oops!"));
+                    }
+                });
             }
-        });
+        };
+        assertThrows(IllegalStateException.class, testMethod);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testThrowExceptionWithException()
     {
-        StubInterface proxy = createProxy(new Trainer<StubInterface>()
+        final StubInterface proxy = createProxy(new Trainer<StubInterface>()
         {
             @Override
             protected void train(StubInterface trainee)
@@ -159,13 +171,20 @@ public abstract class AbstractStubTestCase extends AbstractProxyFactoryAgnosticT
                 thenThrow(new IllegalArgumentException("Nope!"));
             }
         });
-        proxy.voidMethod("Hello");
+        // FIXME Simplification once upgraded to Java 1.8
+        final Executable testMethod = new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                proxy.voidMethod("Hello");
+            }
+        };
+        assertThrows(IllegalArgumentException.class, testMethod);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testThrowExceptionWithProvidedException()
     {
-        StubInterface proxy = createProxy(new Trainer<StubInterface>()
+        final StubInterface proxy = createProxy(new Trainer<StubInterface>()
         {
             @Override
             protected void train(StubInterface trainee)
@@ -174,10 +193,17 @@ public abstract class AbstractStubTestCase extends AbstractProxyFactoryAgnosticT
                 thenThrow(ObjectProviderUtils.constant(new IllegalArgumentException("Nope!")));
             }
         });
-        proxy.voidMethod("Hello");
+        // FIXME Simplification once upgraded to Java 1.8
+        final Executable testMethod = new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                proxy.voidMethod("Hello");
+            }
+        };
+        assertThrows(IllegalArgumentException.class, testMethod);
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test
     public void testThrowingExceptionObject()
     {
         final StubInterface proxy = createProxy(new Trainer<StubInterface>()
@@ -188,10 +214,17 @@ public abstract class AbstractStubTestCase extends AbstractProxyFactoryAgnosticT
                 when(trainee.one("Hello")).thenThrow(new RuntimeException("No way, Jose!"));
             }
         });
-        proxy.one("Hello");
+        // FIXME Simplification once upgraded to Java 1.8
+        final Executable testMethod = new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                proxy.one("Hello");
+            }
+        };
+        assertThrows(RuntimeException.class, testMethod);
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test
     public void testThrowingProvidedException()
     {
         final StubInterface proxy = createProxy(new Trainer<StubInterface>()
@@ -203,27 +236,37 @@ public abstract class AbstractStubTestCase extends AbstractProxyFactoryAgnosticT
                         ObjectProviderUtils.constant(new RuntimeException("No way, Jose!")));
             }
         });
-        proxy.one("Hello");
+        // FIXME Simplification once upgraded to Java 1.8
+        final Executable testMethod = new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                proxy.one("Hello");
+            }
+        };
+        assertThrows(RuntimeException.class, testMethod);
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void testUsingWrongStub()
     {
-        createProxy(new Trainer<StubInterface>()
-        {
+        // FIXME Simplification once upgraded to Java 1.8
+        final Executable testMethod = new Executable() {
             @Override
-            protected void train(final StubInterface parent)
-            {
-                when(parent.stub()).thenStub(new Trainer<StubInterface>()
-                {
+            public void execute() throws Throwable {
+                createProxy(new Trainer<StubInterface>() {
                     @Override
-                    protected void train(final StubInterface child)
-                    {
-                        when(parent.one("Hello")).thenReturn("World");
+                    protected void train(final StubInterface parent) {
+                        when(parent.stub()).thenStub(new Trainer<StubInterface>() {
+                            @Override
+                            protected void train(final StubInterface child) {
+                                when(parent.one("Hello")).thenReturn("World");
+                            }
+                        });
                     }
                 });
             }
-        });
+        };
+        assertThrows(IllegalStateException.class, testMethod);
     }
 
     @Test

--- a/test/src/test/java/org/apache/commons/proxy2/stub/AnnotationBuilderTest.java
+++ b/test/src/test/java/org/apache/commons/proxy2/stub/AnnotationBuilderTest.java
@@ -21,12 +21,14 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
 import org.junit.Test;
+import org.junit.jupiter.api.function.Executable;
 
 /**
  * Test {@link AnnotationBuilder}.
@@ -137,11 +139,18 @@ public class AnnotationBuilderTest
         assertArrayEquals(new FiniteValues[] { FiniteValues.TWO }, nestingAnnotation.children()[1].finiteValues());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testBadMemberMap()
     {
-        AnnotationBuilder.of(CustomAnnotation.class).withMembers(
-                Collections.singletonMap("annString", Integer.valueOf(100)));
+        // FIXME Simplification once upgraded to Java 1.8
+        final Executable testMethod = new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                AnnotationBuilder.of(CustomAnnotation.class).withMembers(
+                        Collections.singletonMap("annString", Integer.valueOf(100)));
+            }
+        };
+        assertThrows(IllegalArgumentException.class, testMethod);
     }
 
     public @interface NestingAnnotation


### PR DESCRIPTION
Convert all legacy junit v4 exception checking to junit v5 assertThrows.

Test not run locally due to this error in master.
```
% mvn clean install
[INFO] Scanning for projects...
[ERROR] [ERROR] The projects in the reactor contain a cyclic reference: Edge between 'Vertex{label='org.apache.commons:commons-proxy2-build-tools:2.1-SNAPSHOT'}' and 'Vertex{label='org.apache.commons:commons-proxy2-parent:2.1-SNAPSHOT'}' introduces to cycle in the graph org.apache.commons:commons-proxy2-parent:2.1-SNAPSHOT --> org.apache.commons:commons-proxy2-build-tools:2.1-SNAPSHOT --> org.apache.commons:commons-proxy2-parent:2.1-SNAPSHOT @ 
[ERROR] The projects in the reactor contain a cyclic reference: Edge between 'Vertex{label='org.apache.commons:commons-proxy2-build-tools:2.1-SNAPSHOT'}' and 'Vertex{label='org.apache.commons:commons-proxy2-parent:2.1-SNAPSHOT'}' introduces to cycle in the graph org.apache.commons:commons-proxy2-parent:2.1-SNAPSHOT --> org.apache.commons:commons-proxy2-build-tools:2.1-SNAPSHOT --> org.apache.commons:commons-proxy2-parent:2.1-SNAPSHOT -> [Help 1]
```